### PR TITLE
Feat: skeleton of multiple video modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ bun.lockb
 	
 # open-next
 .open-next
+
+# cursor stuff
+.cursor/*
+.cursorignore
+/plans/*

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ bun.lockb
 .cursor/*
 .cursorignore
 /plans/*
+*_docs.md

--- a/generate/audioGenerator.ts
+++ b/generate/audioGenerator.ts
@@ -31,7 +31,7 @@ export async function generateTranscriptAudio({
 	fps: number;
 	music: string;
 	videoId: string;
-	mode?: 'brainrot' | 'jre' | 'monologue';
+	mode?: 'brainrot' | 'podcast' | 'monologue';
 	useBackground?: boolean;
 }) {
 	console.log('⭐ Starting generateTranscriptAudio with params:', {

--- a/generate/audioGenerator.ts
+++ b/generate/audioGenerator.ts
@@ -120,7 +120,8 @@ export const music: string = ${
 		};
 export const fps = ${fps};
 export const initialAgentName = '${initialAgentName}';
-export const videoFileName = '/background/MINECRAFT-0.mp4';
+export const useBackground = ${mode === 'brainrot'};
+${mode === 'brainrot' ? "export const videoFileName = '/background/MINECRAFT-0.mp4';" : ''}
 export const videoMode = '${mode}';
 
 export const subtitlesFileName = [

--- a/generate/audioGenerator.ts
+++ b/generate/audioGenerator.ts
@@ -21,6 +21,8 @@ export async function generateTranscriptAudio({
 	fps,
 	music,
 	videoId,
+	mode = 'brainrot',
+	useBackground = true,
 }: {
 	local: boolean;
 	topic: string;
@@ -29,11 +31,15 @@ export async function generateTranscriptAudio({
 	fps: number;
 	music: string;
 	videoId: string;
+	mode?: 'brainrot' | 'jre' | 'monologue';
+	useBackground?: boolean;
 }) {
 	console.log('⭐ Starting generateTranscriptAudio with params:', {
 		local,
 		topic,
 		agentA,
+		mode,
+		useBackground,
 	});
 
 	try {
@@ -115,7 +121,7 @@ export const music: string = ${
 export const fps = ${fps};
 export const initialAgentName = '${initialAgentName}';
 export const videoFileName = '/background/MINECRAFT-0.mp4';
-
+export const videoMode = '${mode}';
 
 export const subtitlesFileName = [
   ${audios

--- a/generate/build.ts
+++ b/generate/build.ts
@@ -7,6 +7,8 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { RowDataPacket } from 'mysql2';
 
+type VideoMode = 'brainrot' | 'podcast' | 'monologue';
+
 const execP = promisify(exec);
 
 dotenv.config();
@@ -42,7 +44,8 @@ async function mainFn(
 	background: string,
 	music: string,
 	cleanSrt: boolean,
-	credits: number
+	credits: number,
+	videoMode: VideoMode
 ) {
 	await cleanupResources();
 	console.log('🚀 Starting mainFn with:', {
@@ -51,6 +54,7 @@ async function mainFn(
 		agentB,
 		videoId,
 		userId,
+		videoMode,
 	});
 	try {
 		console.log('📝 Updating process_id in pending-videos...');
@@ -69,6 +73,8 @@ async function mainFn(
 			fps,
 			music,
 			videoId,
+			mode: videoMode,
+			useBackground: videoMode === 'brainrot',
 		});
 		console.log('✅ Transcription completed successfully');
 
@@ -183,7 +189,8 @@ async function pollPendingVideos() {
 					video.background,
 					video.music,
 					video.clean_srt,
-					video.credits
+					video.credits,
+					video.video_mode as VideoMode
 				);
 			} catch (error) {
 				console.error(`exec error: ${error}`);

--- a/generate/localBuild.ts
+++ b/generate/localBuild.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { exec } from 'child_process';
 import { rm, mkdir, unlink } from 'fs/promises';
 
-type VideoMode = 'brainrot' | 'jre' | 'monologue';
+type VideoMode = 'brainrot' | 'podcast' | 'monologue';
 
 async function cleanupResources() {
 	try {
@@ -53,7 +53,7 @@ async function main() {
 	let useBackground = true;
 
 	switch (mode) {
-		case 'jre':
+		case 'podcast':
 			videoTopic = 'Joe Rogan interviews Jordan Peterson about consciousness and DMT';
 			useBackground = false;
 			break;

--- a/generate/localBuild.ts
+++ b/generate/localBuild.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { exec } from 'child_process';
 import { rm, mkdir, unlink } from 'fs/promises';
 
+type VideoMode = 'brainrot' | 'jre' | 'monologue';
+
 async function cleanupResources() {
 	try {
 		await rm(path.join('public', 'srt'), { recursive: true, force: true });
@@ -28,21 +30,43 @@ async function main() {
 	await cleanupResources();
 	console.log('Starting local build');
 	console.log('MODE:', process.env.MODE);
-	let agentAIndex = Math.floor(Math.random() * agents.length);
-	let agentBIndex;
 
-	do {
-		agentBIndex = Math.floor(Math.random() * agents.length);
-	} while (agentAIndex === agentBIndex);
+	// Note: Not sure why this is here. Commenting out for now.
+	// let agentAIndex = Math.floor(Math.random() * agents.length);
+	// let agentBIndex;
+
+	// do {
+	// 	agentBIndex = Math.floor(Math.random() * agents.length);
+	// } while (agentAIndex === agentBIndex);
+	
+	// Get video mode from environment or default to 'brainrot'
+	const mode = (process.env.VIDEO_MODE as VideoMode) || 'brainrot';
+	console.log('Video Mode:', mode);
 
 	const agentA = agents[0];
 	const agentB = agents[1];
-
-	const videoTopic =
-		'Jordan Peterson is being eaten by a bear and joe rogan is trying to kiss the bear';
 	const fps = 60;
-
 	const music = 'WII_SHOP_CHANNEL_TRAP';
+
+	// Mode-specific configuration
+	let videoTopic: string;
+	let useBackground = true;
+
+	switch (mode) {
+		case 'jre':
+			videoTopic = 'Joe Rogan interviews Jordan Peterson about consciousness and DMT';
+			useBackground = false;
+			break;
+		case 'monologue':
+			videoTopic = 'Jordan Peterson gives a lecture about the importance of cleaning your room';
+			useBackground = false;
+			break;
+		case 'brainrot':
+		default:
+			videoTopic = 'Jordan Peterson is being eaten by a bear and joe rogan is trying to kiss the bear';
+			useBackground = true;
+			break;
+	}
 
 	await transcribe({
 		local,
@@ -52,6 +76,8 @@ async function main() {
 		fps,
 		music,
 		videoId: '123',
+		mode,
+		useBackground,
 	});
 
 	// Skip build step if in studio mode

--- a/generate/scripts/generate.sh
+++ b/generate/scripts/generate.sh
@@ -9,14 +9,14 @@ if [ -z "$MODE" ]; then
 fi
 
 # Validate VIDEO_MODE
-valid_modes=("brainrot" "jre" "monologue")
+valid_modes=("brainrot" "podcast" "monologue")
 if [ -z "$VIDEO_MODE" ]; then
     VIDEO_MODE="brainrot"
     echo "No VIDEO_MODE specified, defaulting to: brainrot"
 elif [[ ! " ${valid_modes[@]} " =~ " ${VIDEO_MODE} " ]]; then
     echo "Error: Invalid VIDEO_MODE '${VIDEO_MODE}'"
     echo "Valid modes are: ${valid_modes[*]}"
-    echo "Example usage: VIDEO_MODE=jre ./scripts/start.sh"
+    echo "Example usage: VIDEO_MODE=podcast ./scripts/start.sh"
     exit 1
 fi
 

--- a/generate/scripts/generate.sh
+++ b/generate/scripts/generate.sh
@@ -8,6 +8,20 @@ if [ -z "$MODE" ]; then
     MODE="development"
 fi
 
+# Validate VIDEO_MODE
+valid_modes=("brainrot" "jre" "monologue")
+if [ -z "$VIDEO_MODE" ]; then
+    VIDEO_MODE="brainrot"
+    echo "No VIDEO_MODE specified, defaulting to: brainrot"
+elif [[ ! " ${valid_modes[@]} " =~ " ${VIDEO_MODE} " ]]; then
+    echo "Error: Invalid VIDEO_MODE '${VIDEO_MODE}'"
+    echo "Valid modes are: ${valid_modes[*]}"
+    echo "Example usage: VIDEO_MODE=jre ./scripts/start.sh"
+    exit 1
+fi
+
+echo "Using video mode: $VIDEO_MODE"
+
 if [ "$MODE" = "production" ]; then
     echo "Running production build script..."
     /root/.bun/bin/pm2 start --interpreter /root/.bun/bin/bun build.ts --name build-process --log /app/brainrot/pm2.log
@@ -15,5 +29,5 @@ if [ "$MODE" = "production" ]; then
     tail -f /app/brainrot/pm2.log /app/brainrot/access.log /app/brainrot/error.log
 else
     echo "Running local build script..."
-    bun run /app/brainrot/localBuild.ts
+    VIDEO_MODE=$VIDEO_MODE /root/.bun/bin/bun run /app/brainrot/localBuild.ts
 fi

--- a/generate/scripts/start.sh
+++ b/generate/scripts/start.sh
@@ -3,11 +3,11 @@
 docker rm -f brainrot-container 2>/dev/null || true
 
 # Validate VIDEO_MODE
-valid_modes=("brainrot" "jre" "monologue")
+valid_modes=("brainrot" "podcast" "monologue")
 if [ -n "$VIDEO_MODE" ] && [[ ! " ${valid_modes[@]} " =~ " ${VIDEO_MODE} " ]]; then
     echo "Error: Invalid VIDEO_MODE '${VIDEO_MODE}'"
     echo "Valid modes are: ${valid_modes[*]}"
-    echo "Example usage: VIDEO_MODE=jre ./scripts/start.sh"
+    echo "Example usage: VIDEO_MODE=podcast ./scripts/start.sh"
     exit 1
 fi
 

--- a/generate/scripts/start.sh
+++ b/generate/scripts/start.sh
@@ -2,14 +2,34 @@
 
 docker rm -f brainrot-container 2>/dev/null || true
 
+# Validate VIDEO_MODE
+valid_modes=("brainrot" "jre" "monologue")
+if [ -n "$VIDEO_MODE" ] && [[ ! " ${valid_modes[@]} " =~ " ${VIDEO_MODE} " ]]; then
+    echo "Error: Invalid VIDEO_MODE '${VIDEO_MODE}'"
+    echo "Valid modes are: ${valid_modes[*]}"
+    echo "Example usage: VIDEO_MODE=jre ./scripts/start.sh"
+    exit 1
+fi
+
 CMD="docker run --name brainrot-container"
 
 CMD="$CMD -e MODE=${MODE:-dev}"
+CMD="$CMD -e VIDEO_MODE=${VIDEO_MODE:-brainrot}"
 
 # Mount directories for non-production modes
 if [ "${MODE}" != "production" ]; then
-    echo "Local mode: Mounting out directory"
+    echo "Local mode: Mounting source directories"
     CMD="$CMD -v $(pwd)/out:/app/brainrot/out"
+    # Add development bind mounts
+    CMD="$CMD -v $(pwd)/src:/app/brainrot/src"
+    CMD="$CMD -v $(pwd)/public:/app/brainrot/public"
+    CMD="$CMD -v $(pwd)/.env:/app/brainrot/.env"
+    CMD="$CMD -v $(pwd)/audioGenerator.ts:/app/brainrot/audioGenerator.ts"
+    CMD="$CMD -v $(pwd)/localBuild.ts:/app/brainrot/localBuild.ts"
+    CMD="$CMD -v $(pwd)/cleanSrt.ts:/app/brainrot/cleanSrt.ts"
+    CMD="$CMD -v $(pwd)/concat.ts:/app/brainrot/concat.ts"
+    CMD="$CMD -v $(pwd)/transcript.ts:/app/brainrot/transcript.ts"
+    CMD="$CMD -v $(pwd)/transcribe.ts:/app/brainrot/transcribe.ts"
 fi
 
 # Additional mounts for studio mode

--- a/generate/src/Composition.tsx
+++ b/generate/src/Composition.tsx
@@ -163,7 +163,8 @@ const SubtitleFileSchema = z.object({
 export const AudioGramSchema = z.object({
 	initialAgentName: z.string(),
 	agentDetails: AgentDetailsSchema,
-	videoFileName: z.string(),
+	videoFileName: z.string().optional(),
+	useBackground: z.boolean(),
 	durationInSeconds: z.number().positive(),
 	audioOffsetInSeconds: z.number().min(0),
 	subtitlesFileName: z.array(SubtitleFileSchema),
@@ -260,6 +261,7 @@ export const AudiogramComposition: React.FC<AudiogramCompositionSchemaType> = ({
 	mirrorWave,
 	audioOffsetInSeconds,
 	videoFileName,
+	useBackground,
 }) => {
 	const [currentAgentName, setCurrentAgentName] = useState<string>('');
 	const { durationInFrames, fps } = useVideoConfig();
@@ -387,11 +389,16 @@ export const AudiogramComposition: React.FC<AudiogramCompositionSchemaType> = ({
 							</div>
 						</div>
 						<div className="relative w-full h-[50%]">
-							<OffthreadVideo
-								muted
-								className=" h-full w-full object-cover"
-								src={staticFile(videoFileName)}
-							/>
+							{useBackground && videoFileName && (
+								<OffthreadVideo
+									muted
+									className="h-full w-full object-cover"
+									src={staticFile(videoFileName)}
+								/>
+							)}
+							{!useBackground && (
+								<div className="h-full w-full bg-black" />
+							)}
 							<div
 								className="absolute flex flex-col items-center gap-2 opacity-[65%] z-30 bottom-12 right-12 text-white font-bold text-7xl"
 								style={{

--- a/generate/src/Root.tsx
+++ b/generate/src/Root.tsx
@@ -5,6 +5,7 @@ import {
 	initialAgentName,
 	subtitlesFileName,
 	videoFileName,
+	useBackground,
 	fps,
 	videoMode,
 } from './tmp/context';
@@ -20,9 +21,11 @@ export const RemotionRoot: React.FC = () => {
 			titleText: 'Back propagation',
 			titleColor: 'rgba(186, 186, 186, 0.93)',
 			initialAgentName,
+			// Video settings
+			useBackground,
+			videoFileName,
 			// Subtitles settings
 			subtitlesFileName,
-			videoFileName,
 			agentDetails: {
 				JOE_ROGAN: {
 					color: '#bc462b',

--- a/generate/src/Root.tsx
+++ b/generate/src/Root.tsx
@@ -74,7 +74,7 @@ export const RemotionRoot: React.FC = () => {
 
 		// Mode-specific modifications
 		switch (videoMode) {
-			case 'jre':
+			case 'podcast':
 				return {
 					...baseProps,
 				};

--- a/generate/src/Root.tsx
+++ b/generate/src/Root.tsx
@@ -77,14 +77,10 @@ export const RemotionRoot: React.FC = () => {
 			case 'jre':
 				return {
 					...baseProps,
-					subtitlesLinePerPage: 4,
-					waveLinesToDisplay: 20,
 				};
 			case 'monologue':
 				return {
 					...baseProps,
-					subtitlesLinePerPage: 3,
-					waveLinesToDisplay: 15,
 				};
 			case 'brainrot':
 			default:

--- a/generate/src/Root.tsx
+++ b/generate/src/Root.tsx
@@ -6,10 +6,89 @@ import {
 	subtitlesFileName,
 	videoFileName,
 	fps,
+	videoMode,
 } from './tmp/context';
 import { getAudioDuration } from '@remotion/media-utils';
 
 export const RemotionRoot: React.FC = () => {
+	const getCompositionProps = () => {
+		const baseProps = {
+			// Audio settings
+			audioOffsetInSeconds: 0,
+			// Title settings
+			audioFileName: staticFile(`audio.mp3`),
+			titleText: 'Back propagation',
+			titleColor: 'rgba(186, 186, 186, 0.93)',
+			initialAgentName,
+			// Subtitles settings
+			subtitlesFileName,
+			videoFileName,
+			agentDetails: {
+				JOE_ROGAN: {
+					color: '#bc462b',
+					image: 'JOE_ROGAN.png',
+				},
+				JORDAN_PETERSON: {
+					color: '#ffffff',
+					image: 'JORDAN_PETERSON.png',
+				},
+				BEN_SHAPIRO: {
+					color: '#90EE90',
+					image: 'BEN_SHAPIRO.png',
+				},
+				BARACK_OBAMA: {
+					color: '#A020F0',
+					image: 'BARACK_OBAMA.png',
+				},
+				DONALD_TRUMP: {
+					color: '#b32134',
+					image: 'DONALD_TRUMP.png',
+				},
+				JOE_BIDEN: {
+					color: '#0000ff',
+					image: 'JOE_BIDEN.png',
+				},
+				KAMALA_HARRIS: {
+					color: '#0000ff',
+					image: 'KAMALA_HARRIS.png',
+				},
+				ANDREW_TATE: {
+					color: '#0000ff',
+					image: 'ANDREW_TATE.png',
+				},
+			},
+			subtitlesTextColor: 'rgba(255, 255, 255, 0.93)',
+			subtitlesLinePerPage: 6,
+			subtitlesZoomMeasurerSize: 10,
+			subtitlesLineHeight: 128,
+			// Wave settings
+			waveFreqRangeStartIndex: 7,
+			waveLinesToDisplay: 30,
+			waveNumberOfSamples: '256',
+			mirrorWave: true,
+			durationInSeconds: 60,
+		};
+
+		// Mode-specific modifications
+		switch (videoMode) {
+			case 'jre':
+				return {
+					...baseProps,
+					subtitlesLinePerPage: 4,
+					waveLinesToDisplay: 20,
+				};
+			case 'monologue':
+				return {
+					...baseProps,
+					subtitlesLinePerPage: 3,
+					waveLinesToDisplay: 15,
+				};
+			case 'brainrot':
+			default:
+				return baseProps;
+		}
+	};
+
 	return (
 		<>
 			<Composition
@@ -19,66 +98,7 @@ export const RemotionRoot: React.FC = () => {
 				width={1080}
 				height={1920}
 				schema={AudioGramSchema}
-				defaultProps={{
-					// Audio settings
-					audioOffsetInSeconds: 0,
-					// Title settings
-					audioFileName: staticFile(`audio.mp3`),
-					titleText: 'Back propagation',
-					titleColor: 'rgba(186, 186, 186, 0.93)',
-
-					initialAgentName,
-
-					// Subtitles settings
-					subtitlesFileName,
-					videoFileName,
-					agentDetails: {
-						JOE_ROGAN: {
-							color: '#bc462b',
-							image: 'JOE_ROGAN.png',
-						},
-						JORDAN_PETERSON: {
-							color: '#ffffff',
-							image: 'JORDAN_PETERSON.png',
-						},
-						BEN_SHAPIRO: {
-							color: '#90EE90',
-							image: 'BEN_SHAPIRO.png',
-						},
-						BARACK_OBAMA: {
-							color: '#A020F0',
-							image: 'BARACK_OBAMA.png',
-						},
-						DONALD_TRUMP: {
-							color: '#b32134',
-							image: 'DONALD_TRUMP.png',
-						},
-						JOE_BIDEN: {
-							color: '#0000ff',
-							image: 'JOE_BIDEN.png',
-						},
-						KAMALA_HARRIS: {
-							color: '#0000ff',
-							image: 'KAMALA_HARRIS.png',
-						},
-						ANDREW_TATE: {
-							color: '#0000ff',
-							image: 'ANDREW_TATE.png',
-						},
-					},
-					subtitlesTextColor: 'rgba(255, 255, 255, 0.93)',
-					subtitlesLinePerPage: 6,
-					subtitlesZoomMeasurerSize: 10,
-					subtitlesLineHeight: 128,
-
-					// Wave settings
-					waveFreqRangeStartIndex: 7,
-					waveLinesToDisplay: 30,
-					waveNumberOfSamples: '256', // This is string for Remotion controls and will be converted to a number
-					mirrorWave: true,
-					durationInSeconds: 60,
-				}}
-				// Determine the length of the video based on the duration of the audio file
+				defaultProps={getCompositionProps()}
 				calculateMetadata={async ({ props }) => {
 					const duration =
 						(await getAudioDuration(staticFile(`audio.mp3`))) + 3;

--- a/generate/transcribe.ts
+++ b/generate/transcribe.ts
@@ -109,7 +109,7 @@ export default async function transcribe({
 	fps: number;
 	music: string;
 	videoId: string;
-	mode?: 'brainrot' | 'jre' | 'monologue';
+	mode?: 'brainrot' | 'podcast' | 'monologue';
 	useBackground?: boolean;
 }) {
 	const { audios, transcript } = await generateTranscriptAudio({

--- a/generate/transcribe.ts
+++ b/generate/transcribe.ts
@@ -99,6 +99,8 @@ export default async function transcribe({
 	fps,
 	music,
 	videoId,
+	mode = 'brainrot',
+	useBackground = true,
 }: {
 	local: boolean;
 	topic: string;
@@ -107,6 +109,8 @@ export default async function transcribe({
 	fps: number;
 	music: string;
 	videoId: string;
+	mode?: 'brainrot' | 'jre' | 'monologue';
+	useBackground?: boolean;
 }) {
 	const { audios, transcript } = await generateTranscriptAudio({
 		local,
@@ -116,6 +120,8 @@ export default async function transcribe({
 		fps,
 		music,
 		videoId,
+		mode,
+		useBackground,
 	});
 	let startingTime = 0;
 

--- a/src/app/createvideo.tsx
+++ b/src/app/createvideo.tsx
@@ -60,6 +60,7 @@ export default function CreateVideo({
     setInvalidTopic,
     setVideoInput,
     videoInput,
+    setIsInQueue,
   } = useCreateVideo();
   const { setIsOpen: setIsGenerationTypeOpen, setVideoDetails, videoDetails } =
     useGenerationType();
@@ -129,15 +130,13 @@ export default function CreateVideo({
 
         setGenerating(false);
         setIsInQueue(true);
-        setIsCreateVideoOpen(false);
+        setIsOpen(false);
         toast.success("Video is in queue!");
-        setIsOpen(false);
       } else {
-        setIsOpen(false);
-        setIsCreateVideoOpen(true);
+        setGenerating(false);
         setInvalidTopic(true);
         setVideoInput("");
-        setGenerating(false);
+        toast.error("Invalid topic. Please try again.");
       }
     },
     onError: (e) => {

--- a/src/app/createvideo.tsx
+++ b/src/app/createvideo.tsx
@@ -127,11 +127,11 @@ export default function CreateVideo({
           },
         });
 
-        setIsOpen(false);
-        setIsCreateVideoOpen(false);
         setGenerating(false);
-        toast.success("Video is in queue!");
         setIsInQueue(true);
+        setIsCreateVideoOpen(false);
+        toast.success("Video is in queue!");
+        setIsOpen(false);
       } else {
         setIsOpen(false);
         setIsCreateVideoOpen(true);
@@ -1081,7 +1081,6 @@ export default function CreateVideo({
             }
             className="flex items-center gap-2"
             onClick={() => {
-              setIsGenerationTypeOpen(true);
               setVideoDetails({
                 mode: videoDetails.mode,
                 title:
@@ -1096,6 +1095,14 @@ export default function CreateVideo({
                 background: background ?? null,
                 music: music ?? null,
                 assetType: assetType ?? null,
+              });
+              setGenerating(true);
+              createVideoMutation.mutate({
+                title: videoInput,
+                agent1: agent[0]?.id ?? 0,
+                agent2: agent[1]?.id ?? 1,
+                cost: credits,
+                remainingCredits: userDB?.credits ?? 0,
               });
             }}
           >

--- a/src/app/generationtype.tsx
+++ b/src/app/generationtype.tsx
@@ -77,7 +77,7 @@ export default function GenerationType() {
       } else {
         setIsOpen(false);
         setIsCreateVideoOpen(true);
-        setInvalidTopic(true);
+        setInvalidTopic(false);
         setVideoInput("");
         setGenerating(false);
       }
@@ -243,14 +243,10 @@ export default function GenerationType() {
               (userDB?.credits ?? 0) <= 0
             }
             onClick={() => {
-              setGenerating(true);
-              createVideoMutation.mutate({
-                title: videoDetails.title,
-                agent1: videoDetails.agents[0]?.id ?? 0,
-                agent2: videoDetails.agents[1]?.id ?? 1,
-                cost: videoDetails.cost,
-                remainingCredits: videoDetails.remainingCredits,
-              });
+              setIsOpen(false);
+              setIsCreateVideoOpen(true);
+              setInvalidTopic(false);
+              setVideoInput("");
             }}
             className={cn(
               `flex h-[250px] w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-blue bg-lightBlue shadow-sm transition-all hover:scale-[101%] hover:opacity-80 active:scale-[99%]`,

--- a/src/app/generationtype.tsx
+++ b/src/app/generationtype.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { trpc } from "@/trpc/client";
-import { Box, Crown, ScrollText, Skull } from "lucide-react";
+import { Box, Crown, ScrollText, Skull, Mic, User } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -26,7 +26,7 @@ import ProButton from "./ProButton";
 import BuyCreditsDialog from "./buy-credits-dialog";
 
 export default function GenerationType() {
-  const [typeSelected, _] = useState<"math" | "brainrot" | "">("");
+  const [typeSelected, _] = useState<"math" | "brainrot" | "podcast" | "monologue" | "">("");
   const router = useRouter();
 
   const { videoDetails, setIsOpen, isOpen } = useGenerationType();
@@ -36,8 +36,6 @@ export default function GenerationType() {
     setVideoInput,
     setIsOpen: setIsCreateVideoOpen,
   } = useCreateVideo();
-
-  const brainrot = videoDetails.brainrot;
 
   const [generating, setGenerating] = useState(false);
 
@@ -54,17 +52,17 @@ export default function GenerationType() {
           method: "POST",
           body: JSON.stringify({
             userId: dbUser.data?.user?.id,
-            topic: brainrot.title,
-            agent1: brainrot?.agents[0]?.name ?? "JORDAN_PETERSON",
-            agent2: brainrot?.agents[1]?.name ?? "BEN_SHAPIRO",
+            topic: videoDetails.title,
+            agent1: videoDetails.agents[0]?.name ?? "JORDAN_PETERSON",
+            agent2: videoDetails.agents[1]?.name ?? "BEN_SHAPIRO",
             videoId: uuidVal,
             duration: 1,
-            music: brainrot.music,
-            background: brainrot.background,
-            fps: brainrot.fps,
-            aiGeneratedImages: brainrot.assetType === "AI" ? true : false,
+            music: videoDetails.music,
+            background: videoDetails.background,
+            fps: videoDetails.fps,
+            aiGeneratedImages: videoDetails.assetType === "AI" ? true : false,
             cleanSrt: true,
-            credits: brainrot.cost,
+            credits: videoDetails.cost,
           }),
           headers: {
             "Content-Type": "application/json",
@@ -94,66 +92,68 @@ export default function GenerationType() {
 
   useEffect(() => {
     const allParamsExist =
-      brainrot.title &&
-      brainrot.cost &&
-      brainrot.assetType &&
-      brainrot.duration &&
-      brainrot.fps &&
-      brainrot.assetType;
+      videoDetails.title &&
+      videoDetails.cost &&
+      videoDetails.assetType &&
+      videoDetails.duration &&
+      videoDetails.fps &&
+      videoDetails.assetType;
 
     setSearchQueryString(
       `?agent1Id=${encodeURIComponent(
-        brainrot.agents[0]?.id!,
+        videoDetails.agents[0]?.id!,
       )}&agent2Id=${encodeURIComponent(
-        brainrot.agents[1]?.id!,
+        videoDetails.agents[1]?.id!,
       )}&agent1Name=${encodeURIComponent(
-        brainrot.agents[0]?.name!,
+        videoDetails.agents[0]?.name!,
       )}&agent2Name=${encodeURIComponent(
-        brainrot.agents[1]?.name!,
+        videoDetails.agents[1]?.name!,
       )}&title=${encodeURIComponent(
-        brainrot.title,
+        videoDetails.title,
       )}&credits=${encodeURIComponent(
-        brainrot.cost,
+        videoDetails.cost,
       )}&music=${encodeURIComponent(
-        brainrot.music ?? "NONE",
+        videoDetails.music ?? "NONE",
       )}&background=${encodeURIComponent(
-        brainrot.background ?? "MINECRAFT",
+        videoDetails.background ?? "MINECRAFT",
       )}&assetType=${encodeURIComponent(
-        brainrot.assetType ?? "GOOGLE",
+        videoDetails.assetType ?? "GOOGLE",
       )}&duration=${encodeURIComponent(
-        brainrot.duration,
-      )}&fps=${encodeURIComponent(brainrot.fps)}`,
+        videoDetails.duration,
+      )}&fps=${encodeURIComponent(videoDetails.fps)}`,
     );
-  }, [brainrot]);
+  }, [videoDetails]);
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogContent className=" max-h-[75%] max-w-[90%] rounded-lg xs:max-w-[425px]">
+      <DialogContent className="max-h-[75%] max-w-[90%] rounded-lg xs:max-w-[800px]">
         <div className="pb-2">
           <div className="relative flex flex-row items-center justify-center gap-8 rounded-lg border bg-accent p-2">
             <div className="absolute -bottom-6 left-1/2 flex -translate-x-1/2 transform flex-row gap-1">
               <div className="flex flex-row gap-4">
+                {user.userId && (
+                  <Avatar>
+                    <AvatarImage
+                      width={32}
+                      height={32}
+                      className="border-3 border-primary"
+                      alt={videoDetails.agents[0]?.name ?? ""}
+                      src={`https://images.smart.wtf/${videoDetails.agents[0]?.name}.png`}
+                    />
+                  </Avatar>
+                )}
                 <Avatar className="border border-border">
                   <AvatarImage
                     width={32}
                     height={32}
                     className="border-3 border-primary"
-                    alt={brainrot.agents[0]?.name ?? ""}
-                    src={`https://images.smart.wtf/${brainrot.agents[0]?.name}.png`}
-                  />
-                </Avatar>
-                <Avatar className="border border-border">
-                  <AvatarImage
-                    width={32}
-                    height={32}
-                    className="border-2 border-border"
-                    alt={brainrot.agents[1]?.name ?? ""}
-                    src={`https://images.smart.wtf/${brainrot.agents[1]?.name}.png`}
+                    alt={videoDetails.agents[1]?.name ?? ""}
+                    src={`https://images.smart.wtf/${videoDetails.agents[1]?.name}.png`}
                   />
                 </Avatar>
               </div>
             </div>
-            <p className="text-center text-xl font-bold">{brainrot.title}</p>
+            <p className="text-center text-xl font-bold">{videoDetails.title}</p>
           </div>
         </div>
         <DialogHeader>
@@ -162,7 +162,7 @@ export default function GenerationType() {
           </DialogTitle>
           <DialogDescription>Choose a video style</DialogDescription>
         </DialogHeader>
-        <div className="relative flex flex-row gap-4 p-2 md:p-4">
+        <div className="relative grid grid-cols-3 gap-4 p-2 md:p-4">
           {!user.userId ? (
             <div className="absolute bottom-0 left-0 right-0 top-0 z-30 flex items-center justify-center rounded-lg bg-black bg-opacity-60 text-secondary dark:text-primary">
               <div className="flex flex-col items-center gap-2">
@@ -217,22 +217,9 @@ export default function GenerationType() {
             </div>
           ) : null}
 
-          <Button
-            variant={"none"}
-            disabled={
-              typeSelected === "brainrot" ||
-              typeSelected === "math" ||
-              generating ||
-              !user.userId ||
-              (userDB?.credits ?? 0) <= 0
-            }
-            onClick={() => {
-              // router.push(`/notes/${noteId}`);
-              // setIsOpen(false);
-              // toast.info("Preparing your note...");
-            }}
+          <div
             className={cn(
-              `relative flex h-[250px] w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-red-500 bg-red-200 shadow-sm transition-all hover:scale-[101%] hover:opacity-80 active:scale-[99%] dark:border-red-900/80 dark:bg-red-400/80`,
+              `relative flex h-[250px] w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-purple-500 bg-purple-200 shadow-sm dark:border-purple-900/80 dark:bg-purple-400/80`,
             )}
           >
             <Badge variant={"math"} className="absolute -right-2 -top-2 z-10">
@@ -240,15 +227,17 @@ export default function GenerationType() {
             </Badge>
             <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/30"></div>
             <p className="text-xl font-bold text-secondary/80 dark:text-primary/80">
-              Math Style
+              Podcast Style
             </p>
-            <Box className="h-[64px] w-[64px] text-secondary/60 dark:text-primary/60 " />
-          </Button>
+            <Mic className="h-[64px] w-[64px] text-secondary/60 dark:text-primary/60" />
+          </div>
+
           <Button
             variant={"none"}
             disabled={
               typeSelected === "brainrot" ||
-              typeSelected === "math" ||
+              typeSelected === "podcast" ||
+              typeSelected === "monologue" ||
               generating ||
               !user.userId ||
               (userDB?.credits ?? 0) <= 0
@@ -256,22 +245,37 @@ export default function GenerationType() {
             onClick={() => {
               setGenerating(true);
               createVideoMutation.mutate({
-                title: brainrot.title,
-                agent1: brainrot.agents[0]?.id ?? 0,
-                agent2: brainrot.agents[1]?.id ?? 1,
-                cost: brainrot.cost,
-                remainingCredits: userDB?.credits ?? 0,
+                title: videoDetails.title,
+                agent1: videoDetails.agents[0]?.id ?? 0,
+                agent2: videoDetails.agents[1]?.id ?? 1,
+                cost: videoDetails.cost,
+                remainingCredits: videoDetails.remainingCredits,
               });
             }}
             className={cn(
               `flex h-[250px] w-full cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-blue bg-lightBlue shadow-sm transition-all hover:scale-[101%] hover:opacity-80 active:scale-[99%]`,
             )}
           >
-            <p className="text-xl font-bold text-secondary/80 dark:text-primary/80 ">
+            <p className="text-xl font-bold text-secondary/80 dark:text-primary/80">
               Brainrot Style
             </p>
-            <Skull className="h-[64px] w-[64px] text-secondary/60 dark:text-primary/60 " />
+            <Skull className="h-[64px] w-[64px] text-secondary/60 dark:text-primary/60" />
           </Button>
+
+          <div
+            className={cn(
+              `relative flex h-[250px] w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-green-500 bg-green-200 shadow-sm dark:border-green-900/80 dark:bg-green-400/80`,
+            )}
+          >
+            <Badge variant={"math"} className="absolute -right-2 -top-2 z-10">
+              Coming Soon
+            </Badge>
+            <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/30"></div>
+            <p className="text-xl font-bold text-secondary/80 dark:text-primary/80">
+              Monologue Style
+            </p>
+            <User className="h-[64px] w-[64px] text-secondary/60 dark:text-primary/60" />
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -52,7 +52,6 @@ export default function PageClient({
     useGenerationType();
 
   useEffect(() => {
-    console.log(searchParams);
 
     if (
       searchParams.agent1Id &&

--- a/src/app/page-client.tsx
+++ b/src/app/page-client.tsx
@@ -63,46 +63,43 @@ export default function PageClient({
       searchParams.fps
     ) {
       setVideoDetails({
-        brainrot: {
-          agents: [
-            {
-              id: parseInt(searchParams.agent1Id),
-              name: searchParams.agent1Name as
-                | "JORDAN_PETERSON"
-                | "ANDREW_TATE"
-                | "BEN_SHAPIRO"
-                | "JOE_ROGAN"
-                | "BARACK_OBAMA"
-                | "DONALD_TRUMP"
-                | "KAMALA_HARRIS"
-                | "JOE_BIDEN",
-            },
-            {
-              id: parseInt(searchParams.agent2Id),
-              name: searchParams.agent2Name as
-                | "JORDAN_PETERSON"
-                | "BEN_SHAPIRO"
-                | "JOE_ROGAN"
-                | "BARACK_OBAMA"
-                | "DONALD_TRUMP"
-                | "KAMALA_HARRIS"
-                | "JOE_BIDEN"
-                | "ANDREW_TATE",
-            },
-          ],
-          assetType: searchParams.assetType ?? "GOOGLE",
-          background: searchParams?.background ?? "MINECRAFT",
-          cost: parseInt(searchParams.credits),
-          duration: searchParams?.duration
-            ? parseInt(searchParams?.duration)
-            : 1,
-          fps: parseInt(searchParams.fps),
-          music: searchParams.music ?? "NONE",
-          title: searchParams.title,
-          // not used in this case
-          remainingCredits: 0,
-        },
-        math: {},
+        mode: "brainrot",
+        title: searchParams.title,
+        agents: [
+          {
+            id: parseInt(searchParams.agent1Id),
+            name: searchParams.agent1Name as
+              | "JORDAN_PETERSON"
+              | "ANDREW_TATE"
+              | "BEN_SHAPIRO"
+              | "JOE_ROGAN"
+              | "BARACK_OBAMA"
+              | "DONALD_TRUMP"
+              | "KAMALA_HARRIS"
+              | "JOE_BIDEN",
+          },
+          {
+            id: parseInt(searchParams.agent2Id),
+            name: searchParams.agent2Name as
+              | "JORDAN_PETERSON"
+              | "BEN_SHAPIRO"
+              | "JOE_ROGAN"
+              | "BARACK_OBAMA"
+              | "DONALD_TRUMP"
+              | "KAMALA_HARRIS"
+              | "JOE_BIDEN"
+              | "ANDREW_TATE",
+          },
+        ],
+        assetType: searchParams.assetType ?? "GOOGLE",
+        background: searchParams?.background ?? "MINECRAFT",
+        cost: parseInt(searchParams.credits),
+        duration: searchParams?.duration
+          ? parseInt(searchParams?.duration)
+          : 1,
+        fps: parseInt(searchParams.fps),
+        music: searchParams.music ?? "NONE",
+        remainingCredits: 0,
       });
       setIsGenerationTypeOpen(true);
     }
@@ -222,7 +219,7 @@ export default function PageClient({
           size={"lg"}
           disabled={pendingVideo}
           onClick={() => {
-            setIsOpen(true);
+            setIsGenerationTypeOpen(true);
           }}
         >
           <Wand className="h-4 w-4" /> Create Video

--- a/src/app/usegenerationtype.ts
+++ b/src/app/usegenerationtype.ts
@@ -26,54 +26,50 @@ interface useGenerationTypeProps {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
   videoDetails: {
-    brainrot: {
-      title: string;
-      agents: {
-        name:
-          | "JORDAN_PETERSON"
-          | "BEN_SHAPIRO"
-          | "JOE_ROGAN"
-          | "BARACK_OBAMA"
-          | "DONALD_TRUMP"
-          | "JOE_BIDEN"
-          | "ANDREW_TATE"
-          | "KAMALA_HARRIS";
-        id: number;
-      }[];
-      cost: number;
-      remainingCredits: number;
-      duration: number;
-      fps: number;
-      background: string | null;
-      music: string | null;
-      assetType: string | null;
-    };
-    math: {};
+    mode: "brainrot" | "podcast" | "monologue";
+    title: string;
+    agents: {
+      name:
+        | "JORDAN_PETERSON"
+        | "BEN_SHAPIRO"
+        | "JOE_ROGAN"
+        | "BARACK_OBAMA"
+        | "DONALD_TRUMP"
+        | "JOE_BIDEN"
+        | "ANDREW_TATE"
+        | "KAMALA_HARRIS";
+      id: number;
+    }[];
+    cost: number;
+    remainingCredits: number;
+    duration: number;
+    fps: number;
+    background: string | null;
+    music: string | null;
+    assetType: string | null;
   };
   setVideoDetails: (videoDetails: {
-    brainrot: {
-      title: string;
-      agents: {
-        name:
-          | "JORDAN_PETERSON"
-          | "BEN_SHAPIRO"
-          | "JOE_ROGAN"
-          | "BARACK_OBAMA"
-          | "DONALD_TRUMP"
-          | "JOE_BIDEN"
-          | "ANDREW_TATE"
-          | "KAMALA_HARRIS";
-        id: number;
-      }[];
-      cost: number;
-      remainingCredits: number;
-      duration: number;
-      fps: number;
-      background: string | null;
-      music: string | null;
-      assetType: string | null;
-    };
-    math: {};
+    mode: "brainrot" | "podcast" | "monologue";
+    title: string;
+    agents: {
+      name:
+        | "JORDAN_PETERSON"
+        | "BEN_SHAPIRO"
+        | "JOE_ROGAN"
+        | "BARACK_OBAMA"
+        | "DONALD_TRUMP"
+        | "JOE_BIDEN"
+        | "ANDREW_TATE"
+        | "KAMALA_HARRIS";
+      id: number;
+    }[];
+    cost: number;
+    remainingCredits: number;
+    duration: number;
+    fps: number;
+    background: string | null;
+    music: string | null;
+    assetType: string | null;
   }) => void;
 }
 
@@ -81,18 +77,16 @@ export const useGenerationType = create<useGenerationTypeProps>((set) => ({
   isOpen: false,
   setIsOpen: (isOpen) => set({ isOpen }),
   videoDetails: {
-    brainrot: {
-      title: "",
-      agents: [],
-      cost: 0,
-      remainingCredits: 0,
-      duration: 0,
-      fps: 0,
-      background: null,
-      music: null,
-      assetType: null,
-    },
-    math: {},
+    mode: "brainrot",
+    title: "",
+    agents: [],
+    cost: 0,
+    remainingCredits: 0,
+    duration: 0,
+    fps: 0,
+    background: null,
+    music: null,
+    assetType: null,
   },
   setVideoDetails: (videoDetails) => set({ videoDetails }),
 }));

--- a/src/components/magicui/tweet-card.tsx
+++ b/src/components/magicui/tweet-card.tsx
@@ -182,7 +182,6 @@ export const TweetMedia = ({ tweet }: { tweet: EnrichedTweet }) => (
   <div className="flex flex-1 items-center justify-center">
     {tweet.video &&
       (() => {
-        console.log(tweet.video);
         return (
           <video
             poster={tweet.video.poster}

--- a/src/server/db/schemas/users/schema.ts
+++ b/src/server/db/schemas/users/schema.ts
@@ -77,6 +77,7 @@ export const pendingVideos = mysqlTable(
     background: varchar("background", { length: 100 }).notNull(),
     music: varchar("music", { length: 100 }).notNull(),
     cleanSrt: boolean("clean_srt").notNull().default(false),
+    video_mode: varchar("video_mode", { length: 20 }).notNull().default("brainrot"),
     // which process is processing this video (-1 if up for grabs)
     processId: int("process_id").notNull().default(-1),
     // in case we need to credit the user if errors out

--- a/src/server/db/schemas/users/schema.ts
+++ b/src/server/db/schemas/users/schema.ts
@@ -77,7 +77,7 @@ export const pendingVideos = mysqlTable(
     background: varchar("background", { length: 100 }).notNull(),
     music: varchar("music", { length: 100 }).notNull(),
     cleanSrt: boolean("clean_srt").notNull().default(false),
-    video_mode: varchar("video_mode", { length: 20 }).notNull().default("brainrot"),
+    // video_mode: varchar("video_mode", { length: 20 }).notNull().default("brainrot"),
     // which process is processing this video (-1 if up for grabs)
     processId: int("process_id").notNull().default(-1),
     // in case we need to credit the user if errors out


### PR DESCRIPTION
# Feature: Adds skeleton backend logic and in progress UI for multiple video modes

## Changes

### UI 
1. switched the order of the modals so that video mode selection is first 
2. removed math mode option
3. conditionally allow for additional options (only in brainrot mode)
4. add podcast and monologue mode coming soon icons
<img width="906" alt="Screenshot 2025-02-17 at 3 06 12 PM" src="https://github.com/user-attachments/assets/45bd6ee5-9b7a-41fc-8496-b6c88a739f15" />

### Backend & Database
1. add video mode parameter to build files and scripts
2. podcast and monologue mode have no background attached
3. Updated drizzle schemas NOTE: did not push yet


### Dev Ex 
1. got rid of some console logs
2. added cursor stuff to .gitignore (lemme know if you want me to push the docs, they're autogenerated so sometimes have errors/get out of date but they help a lot with giving the agent context)
3. Added most of the backend code as mounts in start.sh