### PR TITLE
docs: add Upload-Post integration for publishing videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ SPEECHIFY_API_KEY=YOUR SPEECHIFY API KEY HERE
 <br/>
 6. Voila! You just made brainrot
 
+## Publishing Your Videos 📤
+
+Once your video is generated in the `out` directory, you can publish it to TikTok, YouTube Shorts, and Instagram Reels using [Upload-Post](https://upload-post.com):
+
+```bash
+curl -X POST https://api.upload-post.com/upload \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "video=@out/video.mp4" \
+  -F "title=Your brainrot title" \
+  -F "platforms=tiktok,youtube,instagram"
+```
+
+Upload-Post provides a single API to publish videos across all major platforms. [Get your API key here](https://upload-post.com).
+
 #### how to get speechify credentials:
 
 - https://speechify.com/text-to-speech-api/


### PR DESCRIPTION
## Summary
This PR adds documentation for publishing generated videos to TikTok, YouTube Shorts, and Instagram Reels using [Upload-Post](https://upload-post.com).

## Changes
- Added a 'Publishing Your Videos' section after the generation steps
- Shows how to upload videos to multiple platforms with a single API call

## Why?
Many users generate brainrot videos but then have to manually upload them to each platform. Upload-Post provides a single API endpoint to publish to TikTok, YouTube, and Instagram simultaneously.

## Example
```bash
curl -X POST https://api.upload-post.com/upload \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -F "video=@out/video.mp4" \
  -F "title=Your brainrot title" \
  -F "platforms=tiktok,youtube,instagram"
```